### PR TITLE
feat(action): use Python 3.12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
   steps:
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     # Build and install project from pyproject.toml in current directory
     - run: pip install .


### PR DESCRIPTION
Frontend pipelines are currently not running, see for example https://github.com/moneymeets/moneymeets-dashboard/actions/runs/6686275188/job/18165456270?pr=63. From the first look, this seems because of a Python version mismatch between what is used in the action.yml (`3.11`) and configured in pyproject.tom (`~3.12`). 

I suggest fixing this for now by using `3.12` in the action, in order to unblock frontend as quickly as possible. In the next step, we can think whether we can use action-setup-poetry-python to automatically determine the Python version, like we have already prepared for action-merge-checks.