### PR TITLE
chore(actions): bump GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: moneymeets/action-setup-python-poetry@master
 

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.12'
 


### PR DESCRIPTION
Bump GitHub Actions versions to remove warning "Node 16 is deprecated".